### PR TITLE
[Feature] - 캐릭터 대사 조회 API 구현

### DIFF
--- a/src/main/java/com/heartz/byeboo/adapter/in/web/controller/UserController.java
+++ b/src/main/java/com/heartz/byeboo/adapter/in/web/controller/UserController.java
@@ -1,10 +1,7 @@
 package com.heartz.byeboo.adapter.in.web.controller;
 
 import com.heartz.byeboo.adapter.in.web.dto.request.UserCreateRequestDto;
-import com.heartz.byeboo.adapter.in.web.dto.response.HomeCountResponseDto;
-import com.heartz.byeboo.adapter.in.web.dto.response.UserCreateResponseDto;
-import com.heartz.byeboo.adapter.in.web.dto.response.UserJourneyResponseDto;
-import com.heartz.byeboo.adapter.in.web.dto.response.UserNameResponseDto;
+import com.heartz.byeboo.adapter.in.web.dto.response.*;
 import com.heartz.byeboo.application.command.*;
 import com.heartz.byeboo.application.port.in.UserUseCase;
 import com.heartz.byeboo.core.common.BaseResponse;
@@ -47,5 +44,11 @@ public class UserController {
     public BaseResponse<Void> updateInitialUserJourney(@RequestHeader Long userId) {
         UserJourneyUpdateCommand userJourneyUpdateCommand = UserJourneyUpdateCommand.of(userId);
         return BaseResponse.success(userUseCase.updateInitialUserJourney(userJourneyUpdateCommand));
+    }
+
+    @GetMapping("/users/character")
+    public BaseResponse<UserCharacterResponseDto> getCharacterDialogue(@RequestHeader Long userId) {
+        UserCharacterDialogueCommand userCharacterDialogueCommand = UserCharacterDialogueCommand.of(userId);
+        return BaseResponse.success(userUseCase.getCharacterDialogue(userCharacterDialogueCommand));
     }
 }

--- a/src/main/java/com/heartz/byeboo/adapter/in/web/dto/response/UserCharacterResponseDto.java
+++ b/src/main/java/com/heartz/byeboo/adapter/in/web/dto/response/UserCharacterResponseDto.java
@@ -1,0 +1,9 @@
+package com.heartz.byeboo.adapter.in.web.dto.response;
+
+public record UserCharacterResponseDto(
+        String dialogue
+) {
+    public static UserCharacterResponseDto of(String dialogue) {
+        return new UserCharacterResponseDto(dialogue);
+    }
+}

--- a/src/main/java/com/heartz/byeboo/application/command/ActiveQuestCreateCommand.java
+++ b/src/main/java/com/heartz/byeboo/application/command/ActiveQuestCreateCommand.java
@@ -1,11 +1,9 @@
 package com.heartz.byeboo.application.command;
 
 import com.heartz.byeboo.adapter.in.web.dto.request.ActiveQuestRequestDto;
-import com.heartz.byeboo.constants.TextConstant;
+import com.heartz.byeboo.constants.QuestConstants;
 import com.heartz.byeboo.core.exception.CustomException;
-import com.heartz.byeboo.domain.exception.QuestErrorCode;
 import com.heartz.byeboo.domain.exception.UserQuestErrorCode;
-import com.heartz.byeboo.domain.model.User;
 import com.heartz.byeboo.domain.type.EQuestEmotionState;
 import com.heartz.byeboo.utils.TextUtil;
 import lombok.Builder;
@@ -38,7 +36,7 @@ public class ActiveQuestCreateCommand {
     }
 
     private static void validateAnswerLength(String answer){
-        if (TextUtil.lengthWithEmoji(answer) > TextConstant.ACTIVE_QUEST_ANSWER_MAX){
+        if (TextUtil.lengthWithEmoji(answer) > QuestConstants.ACTIVE_QUEST_ANSWER_MAX){
             throw new CustomException(UserQuestErrorCode.ACTIVE_ANSWER_TOO_LONG);
         }
     }

--- a/src/main/java/com/heartz/byeboo/application/command/RecordingQuestCreateCommand.java
+++ b/src/main/java/com/heartz/byeboo/application/command/RecordingQuestCreateCommand.java
@@ -1,11 +1,9 @@
 package com.heartz.byeboo.application.command;
 
 import com.heartz.byeboo.adapter.in.web.dto.request.RecordingQuestRequestDto;
-import com.heartz.byeboo.constants.TextConstant;
+import com.heartz.byeboo.constants.QuestConstants;
 import com.heartz.byeboo.core.exception.CustomException;
-import com.heartz.byeboo.domain.exception.QuestErrorCode;
 import com.heartz.byeboo.domain.exception.UserQuestErrorCode;
-import com.heartz.byeboo.domain.model.User;
 import com.heartz.byeboo.domain.type.EQuestEmotionState;
 import com.heartz.byeboo.utils.TextUtil;
 import lombok.Builder;
@@ -34,11 +32,11 @@ public class RecordingQuestCreateCommand {
     }
 
     private static void validateAnswerLength(String answer){
-        if (TextUtil.lengthWithEmoji(answer) > TextConstant.RECORDING_QUEST_ANSWER_MAX){
+        if (TextUtil.lengthWithEmoji(answer) > QuestConstants.RECORDING_QUEST_ANSWER_MAX){
             throw new CustomException(UserQuestErrorCode.RECORDING_ANSWER_TOO_LONG);
         }
 
-        if (TextUtil.lengthWithEmoji(answer) < TextConstant.RECORDING_QUEST_ANSWER_MIN){
+        if (TextUtil.lengthWithEmoji(answer) < QuestConstants.RECORDING_QUEST_ANSWER_MIN){
             throw new CustomException(UserQuestErrorCode.RECORDING_ANSWER_TOO_SHORT);
         }
     }

--- a/src/main/java/com/heartz/byeboo/application/command/UserCharacterDialogueCommand.java
+++ b/src/main/java/com/heartz/byeboo/application/command/UserCharacterDialogueCommand.java
@@ -1,0 +1,17 @@
+package com.heartz.byeboo.application.command;
+
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserCharacterDialogueCommand {
+    private Long id;
+
+    public static UserCharacterDialogueCommand of(Long id) {
+        return UserCharacterDialogueCommand.builder()
+                .id(id)
+                .build();
+    }
+}

--- a/src/main/java/com/heartz/byeboo/application/port/in/UserUseCase.java
+++ b/src/main/java/com/heartz/byeboo/application/port/in/UserUseCase.java
@@ -1,9 +1,6 @@
 package com.heartz.byeboo.application.port.in;
 
-import com.heartz.byeboo.adapter.in.web.dto.response.HomeCountResponseDto;
-import com.heartz.byeboo.adapter.in.web.dto.response.UserCreateResponseDto;
-import com.heartz.byeboo.adapter.in.web.dto.response.UserJourneyResponseDto;
-import com.heartz.byeboo.adapter.in.web.dto.response.UserNameResponseDto;
+import com.heartz.byeboo.adapter.in.web.dto.response.*;
 import com.heartz.byeboo.application.command.*;
 
 public interface UserUseCase {
@@ -12,4 +9,5 @@ public interface UserUseCase {
     UserJourneyResponseDto getUserJourney(UserJourneyCommand userJourneyCommand);
     HomeCountResponseDto getCompletedCount(CompletedCountCommand completedCountCommand);
     Void updateInitialUserJourney(UserJourneyUpdateCommand userJourneyUpdateCommand);
+    UserCharacterResponseDto getCharacterDialogue(UserCharacterDialogueCommand userCharacterDialogueCommand);
 }

--- a/src/main/java/com/heartz/byeboo/application/service/UserQuestService.java
+++ b/src/main/java/com/heartz/byeboo/application/service/UserQuestService.java
@@ -20,7 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.heartz.byeboo.constants.TextConstant.QUEST_COUNT_MAX;
+import static com.heartz.byeboo.constants.QuestConstants.QUEST_COUNT_MAX;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/heartz/byeboo/application/service/UserService.java
+++ b/src/main/java/com/heartz/byeboo/application/service/UserService.java
@@ -4,6 +4,7 @@ import com.heartz.byeboo.adapter.in.web.dto.response.*;
 import com.heartz.byeboo.application.command.*;
 import com.heartz.byeboo.application.port.in.UserUseCase;
 import com.heartz.byeboo.application.port.out.*;
+import com.heartz.byeboo.constants.QuestConstants;
 import com.heartz.byeboo.core.exception.CustomException;
 import com.heartz.byeboo.domain.exception.UserJourneyErrorCode;
 import com.heartz.byeboo.domain.exception.UserQuestErrorCode;
@@ -149,15 +150,15 @@ public class UserService implements UserUseCase {
     }
 
     private Boolean isBeforeStart(User user) {
-        return user.getCurrentNumber() == 0;
+        return user.getCurrentNumber() == QuestConstants.QUEST_BEFORE_START_COUNT;
     }
 
     private Boolean isInitialStart(User user) {
-        return user.getCurrentNumber() == 1;
+        return user.getCurrentNumber() == QuestConstants.QUEST_INITIAL_START_COUNT;
     }
 
     private Boolean isCompleted(User user) {
-        return user.getCurrentNumber() == 31;
+        return user.getCurrentNumber() == QuestConstants.QUEST_COUNT_MAX;
     }
 
     private Boolean isTodayCompleted(UserQuest recentUserQuest) {

--- a/src/main/java/com/heartz/byeboo/constants/QuestConstants.java
+++ b/src/main/java/com/heartz/byeboo/constants/QuestConstants.java
@@ -1,9 +1,11 @@
 package com.heartz.byeboo.constants;
 
-public class TextConstant {
+public class QuestConstants {
 
     public static final int RECORDING_QUEST_ANSWER_MAX = 500;
     public static final int RECORDING_QUEST_ANSWER_MIN = 10;
     public static final int ACTIVE_QUEST_ANSWER_MAX = 200;
+    public static final int QUEST_BEFORE_START_COUNT = 0;
+    public static final int QUEST_INITIAL_START_COUNT = 1;
     public static final int QUEST_COUNT_MAX = 31;
 }

--- a/src/main/java/com/heartz/byeboo/domain/type/ECharacterDialogue.java
+++ b/src/main/java/com/heartz/byeboo/domain/type/ECharacterDialogue.java
@@ -1,0 +1,22 @@
+package com.heartz.byeboo.domain.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ECharacterDialogue {
+    BEFORE_START("제가 %s님의 이별 극복을 도와드릴게요."),
+    START("천천히, 하지만 분명하게. 오늘도 나아가봐요."),
+    IN_PROGRESS("괜찮아질 거예요. 오늘도 여기까지 잘 왔으니까요."),
+    COMPLETED("저는 언제나 여기 있어요 :)");
+
+    private final String dialogue;
+
+    public String getDialogue(String userName) {
+        if (this == BEFORE_START) {
+            return String.format(dialogue, userName);
+        }
+        return dialogue;
+    }
+}

--- a/src/main/java/com/heartz/byeboo/domain/type/EQuestEmotionState.java
+++ b/src/main/java/com/heartz/byeboo/domain/type/EQuestEmotionState.java
@@ -6,10 +6,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum EQuestEmotionState {
-    NEUTRAL("그저 그런"),
-    SAD("슬픈"),
-    RELIEVED("후련함"),
-    SELF_UNDERSTANDING("자기 이해");
+    NEUTRAL("그저 그런", "특별한 감정이 없었을 수도 있어요. 하지만 그런 날에도, 당신은 스스로를 이해하는 연습을 하고 있다는 걸 잊지 마세요."),
+    SAD("슬픔", "마음이 조금 무거웠을지도 몰라요. 하지만 그 감정을 마주한 것만으로도, 이미 한 걸음 나아간 거예요."),
+    RELIEVED("후련함", "마음이 가벼워졌다면 다행이에요. 당신은 지금 아주 건강하게 감정을 정리하고 있어요."),
+    SELF_UNDERSTANDING("자기 이해", "퀘스트를 통해 스스로에 대해 더 잘 알게 되셨네요! 아주 바람직하게 나아가고 있어요.");
 
     private final String label;
+    private final String description;
 }


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #34 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [x] 캐릭터 대사 조회 API 구현

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
캐릭터 대사 조회 로직이 퀘스트 시작 직전, 퀘스트 미진행, 퀘스트 완료, 여정 완료의 4가지 경우로 나뉘어져 있어 분기 처리에 신경을 써야할 것 같습니다. 퀘스트 시작 직전, 퀘스트 미진행, 퀘스트 완료, 여정 완료의 경우 userQuest, userJourney, user를 한번에 봐야하기 때문에 로직이 복잡해진 것 같은데, 이 부분 보시면서 좋은 아이디어가 있으면 말씀해주세요!