### PR TITLE
Refactor : 애플 회원 탈퇴에서 authorization_code 헤더로 안받도록 로직 수정

### DIFF
--- a/src/main/java/com/heartz/byeboo/adapter/in/web/controller/OAuthController.java
+++ b/src/main/java/com/heartz/byeboo/adapter/in/web/controller/OAuthController.java
@@ -54,9 +54,12 @@ public class OAuthController {
     @PostMapping("/login")
     public BaseResponse<UserLoginResponse> login(
             @Parameter(hidden = true) @RequestHeader(HttpHeaders.AUTHORIZATION) final String token,
+            @Nullable
+            @Schema(description = "널 가능(애플 회원 로그인시에만 요청)")
+            @RequestHeader("X-Apple-Code") final String code,
             @RequestBody final UserLoginRequestDto request){
         String rawToken = token.substring(AuthConstants.OAuth2.PREFIX_BEARER.length()).trim();
-        return BaseResponse.success(oAuthUseCase.login(OAuthLoginCommand.of(request.platform(), rawToken)));
+        return BaseResponse.success(oAuthUseCase.login(OAuthLoginCommand.of(request.platform(), rawToken, code)));
     }
 
     @Operation(
@@ -104,11 +107,8 @@ public class OAuthController {
             }
     )
     @DeleteMapping("/withdraw")
-    public BaseResponse<Void> withdraw(@UserId final Long userId,
-                                         @Nullable
-                                         @Schema(description = "널 가능(애플 회원 탈퇴시에만 요청)")
-                                         @RequestHeader("X-Apple-Code") final String code) {
-        return BaseResponse.success(oAuthUseCase.withdraw(OAuthWithdrawCommand.of(userId, code)));
+    public BaseResponse<Void> withdraw(@UserId final Long userId) {
+        return BaseResponse.success(oAuthUseCase.withdraw(OAuthWithdrawCommand.of(userId)));
     }
 
     @Operation(

--- a/src/main/java/com/heartz/byeboo/adapter/out/OAuthUserInfoAdapter.java
+++ b/src/main/java/com/heartz/byeboo/adapter/out/OAuthUserInfoAdapter.java
@@ -1,5 +1,7 @@
 package com.heartz.byeboo.adapter.out;
 
+import com.heartz.byeboo.application.command.auth.ProviderUserInfoCommand;
+import com.heartz.byeboo.application.command.auth.UserInfoCommand;
 import com.heartz.byeboo.application.port.out.userinfo.RetrieveUserInfoPort;
 import com.heartz.byeboo.application.port.out.userinfo.UnlinkUserInfoPort;
 import com.heartz.byeboo.domain.type.EPlatform;
@@ -16,14 +18,14 @@ public class OAuthUserInfoAdapter implements RetrieveUserInfoPort, UnlinkUserInf
     private final OAuthProviderFactory oAuthProviderFactory;
 
     @Override
-    public SocialInfoResponse getUserInfo(String token, EPlatform platform) {
-        OAuthProvider oAuthProvider = oAuthProviderFactory.findProvider(platform);
-        return oAuthProvider.getUserInfo(token);
+    public SocialInfoResponse getUserInfo(UserInfoCommand command) {
+        OAuthProvider oAuthProvider = oAuthProviderFactory.findProvider(command.platform());
+        return oAuthProvider.getUserInfo(ProviderUserInfoCommand.of(command.token(), command.code()));
     }
 
     @Override
-    public void revoke(EPlatform platform, String code, String serialId) {
+    public void revoke(EPlatform platform, String refreshToken, String serialId) {
         OAuthProvider oAuthProvider = oAuthProviderFactory.findProvider(platform);
-        oAuthProvider.requestRevoke(code, serialId);
+        oAuthProvider.requestRevoke(refreshToken, serialId);
     }
 }

--- a/src/main/java/com/heartz/byeboo/adapter/out/persistence/entity/UserEntity.java
+++ b/src/main/java/com/heartz/byeboo/adapter/out/persistence/entity/UserEntity.java
@@ -51,8 +51,11 @@ public class UserEntity extends BaseEntity{
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
     @Builder
-    public UserEntity(Long id, String name, EQuestStyle questStyle, EJourney journey,Long currentNumber,EPlatform platform, ERole role, String serialId, EUserStatus status, LocalDateTime deletedAt) {
+    public UserEntity(Long id, String name, EQuestStyle questStyle, EJourney journey,Long currentNumber,EPlatform platform, ERole role, String serialId, EUserStatus status, LocalDateTime deletedAt, String refreshToken) {
         this.id = id;
         this.name = name;
         this.questStyle = questStyle;
@@ -63,9 +66,10 @@ public class UserEntity extends BaseEntity{
         this.serialId = serialId;
         this.status = status;
         this.deletedAt = deletedAt;
+        this.refreshToken = refreshToken;
     }
 
-    public static UserEntity create(String name, EQuestStyle questStyle, EJourney journey, Long currentNumber, EPlatform platform, ERole role, String serialId, EUserStatus status, LocalDateTime deletedAt) {
+    public static UserEntity create(String name, EQuestStyle questStyle, EJourney journey, Long currentNumber, EPlatform platform, ERole role, String serialId, EUserStatus status, LocalDateTime deletedAt, String refreshToken) {
         return UserEntity.builder()
                 .name(name)
                 .questStyle(questStyle)
@@ -76,10 +80,11 @@ public class UserEntity extends BaseEntity{
                 .role(role)
                 .status(status)
                 .deletedAt(deletedAt)
+                .refreshToken(refreshToken)
                 .build();
     }
 
-    public static UserEntity createForUpdate(Long id, String name, EQuestStyle questStyle, EJourney journey,Long currentNumber, EPlatform platform, ERole role, String serialId, EUserStatus status, LocalDateTime deletedAt) {
+    public static UserEntity createForUpdate(Long id, String name, EQuestStyle questStyle, EJourney journey,Long currentNumber, EPlatform platform, ERole role, String serialId, EUserStatus status, LocalDateTime deletedAt, String refreshToken) {
         return UserEntity.builder()
                 .id(id)
                 .name(name)
@@ -91,6 +96,7 @@ public class UserEntity extends BaseEntity{
                 .platform(platform)
                 .status(status)
                 .deletedAt(deletedAt)
+                .refreshToken(refreshToken)
                 .build();
     }
 }

--- a/src/main/java/com/heartz/byeboo/application/command/auth/OAuthLoginCommand.java
+++ b/src/main/java/com/heartz/byeboo/application/command/auth/OAuthLoginCommand.java
@@ -6,18 +6,19 @@ import com.heartz.byeboo.domain.type.EPlatform;
 import lombok.Builder;
 import lombok.Getter;
 
-@Getter
 @Builder
-public class OAuthLoginCommand {
+public record OAuthLoginCommand(
+        EPlatform platform,
+        String token,
+        String code
+) {
 
-    private EPlatform platform;
-    private String token;
-
-    public static OAuthLoginCommand of(String platform, String token){
+    public static OAuthLoginCommand of(String platform, String token, String code){
         try {
             return OAuthLoginCommand.builder()
                     .platform(EPlatform.valueOf(platform))
                     .token(token)
+                    .code(code)
                     .build();
         } catch (IllegalArgumentException e){
             throw new CustomException(AuthErrorCode.INVALID_PLATFORM);

--- a/src/main/java/com/heartz/byeboo/application/command/auth/OAuthWithdrawCommand.java
+++ b/src/main/java/com/heartz/byeboo/application/command/auth/OAuthWithdrawCommand.java
@@ -1,10 +1,9 @@
 package com.heartz.byeboo.application.command.auth;
 
 public record OAuthWithdrawCommand(
-        Long userId,
-        String code
+        Long userId
 ) {
-    public static OAuthWithdrawCommand of(Long userId, String code){
-        return new OAuthWithdrawCommand(userId, code);
+    public static OAuthWithdrawCommand of(Long userId){
+        return new OAuthWithdrawCommand(userId);
     }
 }

--- a/src/main/java/com/heartz/byeboo/application/command/auth/ProviderUserInfoCommand.java
+++ b/src/main/java/com/heartz/byeboo/application/command/auth/ProviderUserInfoCommand.java
@@ -1,0 +1,16 @@
+package com.heartz.byeboo.application.command.auth;
+
+import lombok.Builder;
+
+@Builder
+public record ProviderUserInfoCommand(
+        String providerToken,
+        String authorizationCode
+) {
+    public static ProviderUserInfoCommand of(String providerToken, String authorizationCode){
+        return ProviderUserInfoCommand.builder()
+                .providerToken(providerToken)
+                .authorizationCode(authorizationCode)
+                .build();
+    }
+}

--- a/src/main/java/com/heartz/byeboo/application/command/auth/UserInfoCommand.java
+++ b/src/main/java/com/heartz/byeboo/application/command/auth/UserInfoCommand.java
@@ -1,0 +1,21 @@
+package com.heartz.byeboo.application.command.auth;
+
+import com.heartz.byeboo.domain.type.EPlatform;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+public record UserInfoCommand(
+
+        EPlatform platform,
+        String token,
+        String code
+) {
+    public static UserInfoCommand of(EPlatform platform, String token, String code){
+            return UserInfoCommand.builder()
+                    .platform(platform)
+                    .token(token)
+                    .code(code)
+                    .build();
+    }
+}

--- a/src/main/java/com/heartz/byeboo/application/port/in/dto/response/auth/UserInfoResponse.java
+++ b/src/main/java/com/heartz/byeboo/application/port/in/dto/response/auth/UserInfoResponse.java
@@ -4,9 +4,10 @@ import com.heartz.byeboo.domain.type.EPlatform;
 
 public record UserInfoResponse(
         EPlatform platform,
-        String serialId
+        String serialId,
+        String refreshToken
 ) {
-    public static UserInfoResponse of(EPlatform platform, String serialId){
-        return new UserInfoResponse(platform, serialId);
+    public static UserInfoResponse of(EPlatform platform, String serialId, String refreshToken){
+        return new UserInfoResponse(platform, serialId, refreshToken);
     }
 }

--- a/src/main/java/com/heartz/byeboo/application/port/out/userinfo/RetrieveUserInfoPort.java
+++ b/src/main/java/com/heartz/byeboo/application/port/out/userinfo/RetrieveUserInfoPort.java
@@ -1,8 +1,9 @@
 package com.heartz.byeboo.application.port.out.userinfo;
 
+import com.heartz.byeboo.application.command.auth.UserInfoCommand;
 import com.heartz.byeboo.domain.type.EPlatform;
 import com.heartz.byeboo.infrastructure.dto.SocialInfoResponse;
 
 public interface RetrieveUserInfoPort {
-    SocialInfoResponse getUserInfo(final String token, final EPlatform platform);
+    SocialInfoResponse getUserInfo(UserInfoCommand command);
 }

--- a/src/main/java/com/heartz/byeboo/application/port/out/userinfo/UnlinkUserInfoPort.java
+++ b/src/main/java/com/heartz/byeboo/application/port/out/userinfo/UnlinkUserInfoPort.java
@@ -3,5 +3,5 @@ package com.heartz.byeboo.application.port.out.userinfo;
 import com.heartz.byeboo.domain.type.EPlatform;
 
 public interface UnlinkUserInfoPort {
-    void revoke(final EPlatform platform, final String code, final String serialId);
+    void revoke(final EPlatform platform, final String refreshToken, final String serialId);
 }

--- a/src/main/java/com/heartz/byeboo/application/service/auth/OAuthProvider.java
+++ b/src/main/java/com/heartz/byeboo/application/service/auth/OAuthProvider.java
@@ -1,10 +1,11 @@
 package com.heartz.byeboo.application.service.auth;
 
+import com.heartz.byeboo.application.command.auth.ProviderUserInfoCommand;
 import com.heartz.byeboo.infrastructure.dto.SocialInfoResponse;
 
 
 public interface OAuthProvider {
 
-    SocialInfoResponse getUserInfo(final String providerToken);
-    void requestRevoke(String code, String serialId);
+    SocialInfoResponse getUserInfo(ProviderUserInfoCommand command);
+    void requestRevoke(String refreshToken, String serialId);
 }

--- a/src/main/java/com/heartz/byeboo/application/service/auth/OAuthService.java
+++ b/src/main/java/com/heartz/byeboo/application/service/auth/OAuthService.java
@@ -1,10 +1,7 @@
 package com.heartz.byeboo.application.service.auth;
 
 import com.heartz.byeboo.adapter.out.OAuthUserInfoAdapter;
-import com.heartz.byeboo.application.command.auth.OAuthLoginCommand;
-import com.heartz.byeboo.application.command.auth.OAuthLogoutCommand;
-import com.heartz.byeboo.application.command.auth.OAuthWithdrawCommand;
-import com.heartz.byeboo.application.command.auth.ReissueCommand;
+import com.heartz.byeboo.application.command.auth.*;
 import com.heartz.byeboo.application.port.in.dto.response.auth.UserInfoResponse;
 import com.heartz.byeboo.application.port.in.dto.response.auth.UserLoginResponse;
 import com.heartz.byeboo.application.port.in.dto.response.auth.UserReissueResponse;
@@ -56,8 +53,8 @@ public class OAuthService implements OAuthUseCase {
     @Transactional
     @Override
     public UserLoginResponse login(OAuthLoginCommand command) {
-        SocialInfoResponse response = oAuthUserInfoAdapter.getUserInfo(command.getToken(), command.getPlatform());
-        UserInfoResponse userInfoResponse = UserInfoResponse.of(command.getPlatform(), response.serialId());
+        SocialInfoResponse response = oAuthUserInfoAdapter.getUserInfo(UserInfoCommand.of(command.platform(), command.token(), command.code()));
+        UserInfoResponse userInfoResponse = UserInfoResponse.of(command.platform(), response.serialId(), response.refreshToken());
         Optional<User> user = retrieveUserPort.findUserByPlatFormAndSeralId(userInfoResponse.platform(), userInfoResponse.serialId());
         boolean isRegistered = isRegistered(user);
         User findUser = loadOrCreateUser(user, userInfoResponse);
@@ -98,7 +95,7 @@ public class OAuthService implements OAuthUseCase {
     @Transactional
     public Void withdraw(OAuthWithdrawCommand command) {
         User findUser = retrieveUserPort.getUserById(command.userId());
-        oAuthUserInfoAdapter.revoke(findUser.getPlatform(), command.code(), findUser.getSerialId());
+        oAuthUserInfoAdapter.revoke(findUser.getPlatform(), findUser.getRefreshToken(), findUser.getSerialId());
         findUser.softDelete();
         updateUserPort.updateUser(findUser);
         return null;
@@ -129,9 +126,8 @@ public class OAuthService implements OAuthUseCase {
         return findUser.orElseGet(() -> createNewUser(userInfo));
     }
 
-
     private User createNewUser(final UserInfoResponse userInfo) {
-        User newUser = UserMapper.userInfoToDomain(userInfo.serialId(), userInfo.platform(), ERole.USER);
+        User newUser = UserMapper.userInfoToDomain(userInfo.serialId(), userInfo.platform(), ERole.USER, userInfo.refreshToken());
         return createUserPort.createUser(newUser);
     }
 

--- a/src/main/java/com/heartz/byeboo/domain/exception/AuthErrorCode.java
+++ b/src/main/java/com/heartz/byeboo/domain/exception/AuthErrorCode.java
@@ -15,6 +15,7 @@ public enum AuthErrorCode implements ErrorCode {
     FAILED_TO_LOAD_PRIVATE_KEY(HttpStatus.BAD_REQUEST, "개인 키를 로드하는 데 실패했습니다."),
     APPLE_REVOKE_FAILED(HttpStatus.BAD_REQUEST, "Apple 탈퇴에 실패했습니다."),
     APPLE_INVALID_PRIVATE_KEY(HttpStatus.BAD_REQUEST, "올바르지 않은 키가 사용되었습니다."),
+    APPLE_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "Apple 로그인에 실패했습니다."),
 
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "리소스 접근 권한이 없습니다."),
     INVALID_PLATFORM(HttpStatus.UNAUTHORIZED,"올바르지 않은 로그인 방식입니다."),

--- a/src/main/java/com/heartz/byeboo/domain/model/User.java
+++ b/src/main/java/com/heartz/byeboo/domain/model/User.java
@@ -22,8 +22,9 @@ public class User {
     private ERole role;
     private EUserStatus status;
     private LocalDateTime deletedAt;
+    private String refreshToken;
 
-    public static User of(Long id, String name, EQuestStyle questStyle, EJourney journey, Long currentNumber, EPlatform platform, ERole role, String serialId, EUserStatus status, LocalDateTime deletedAt) {
+    public static User of(Long id, String name, EQuestStyle questStyle, EJourney journey, Long currentNumber, EPlatform platform, ERole role, String serialId, EUserStatus status, LocalDateTime deletedAt, String refreshToken) {
         return User.builder()
                 .id(id)
                 .name(name)
@@ -35,6 +36,7 @@ public class User {
                 .platform(platform)
                 .status(status)
                 .deletedAt(deletedAt)
+                .refreshToken(refreshToken)
                 .build();
     }
 
@@ -62,6 +64,7 @@ public class User {
         updateStatus(INACTIVE);
         updateDeletedAt(LocalDateTime.now());
         this.name = DELETED_USER_DEFAULT_INFO;
+        deleteRefreshToken();
     }
 
     public void updateStatus(final EUserStatus userStatus) {
@@ -74,5 +77,9 @@ public class User {
 
     public void updateJourney(final EJourney journey) {
         this.journey = journey;
+    }
+
+    public void deleteRefreshToken(){
+        this.refreshToken = null;
     }
 }

--- a/src/main/java/com/heartz/byeboo/infrastructure/api/apple/AppleOAuthProvider.java
+++ b/src/main/java/com/heartz/byeboo/infrastructure/api/apple/AppleOAuthProvider.java
@@ -1,5 +1,6 @@
 package com.heartz.byeboo.infrastructure.api.apple;
 
+import com.heartz.byeboo.application.command.auth.ProviderUserInfoCommand;
 import com.heartz.byeboo.constants.AuthConstants;
 import com.heartz.byeboo.core.exception.CustomException;
 import com.heartz.byeboo.domain.exception.AuthErrorCode;
@@ -28,21 +29,30 @@ public class AppleOAuthProvider implements OAuthProvider {
     private String clientId;
 
     @Override
-    public SocialInfoResponse getUserInfo(final String identityToken) {
-        Map<String, String> headers = appleIdentityTokenParser.parseHeaders(identityToken);
+    public SocialInfoResponse getUserInfo(final ProviderUserInfoCommand command) {
+        Map<String, String> headers = appleIdentityTokenParser.parseHeaders(command.providerToken());
         ApplePublicKeys applePublicKeys = appleFeignClient.getApplePublicKey();
+
         PublicKey applePublicKey = applePublicKeyGenerator.generatePublicKey(headers, applePublicKeys);
-        Claims claims = appleIdentityTokenParser.parsePublicKeyAndGetClaims(identityToken, applePublicKey);
+        Claims claims = appleIdentityTokenParser.parsePublicKeyAndGetClaims(command.providerToken(), applePublicKey);
+        String refreshToken;
+        try {
+            String clientSecret = appleClientSecretGenerator.generateClientSecret();
+            refreshToken = getAppleRefreshToken(command.authorizationCode(), clientSecret);
+        } catch (Exception e) {
+            throw new CustomException(AuthErrorCode.APPLE_LOGIN_FAILED);
+        }
         return SocialInfoResponse.of(
-                claims.get("sub").toString()
+                claims.get("sub").toString(),
+                refreshToken
         );
     }
 
     @Override
-    public void requestRevoke(final String authorizationCode, final String serialId) {
+    public void requestRevoke(String refreshToken, final String serialId) {
         try {
+            System.out.println("리프레"+refreshToken);
             String clientSecret = appleClientSecretGenerator.generateClientSecret();
-            String refreshToken = getAppleRefreshToken(authorizationCode, clientSecret);
             appleFeignClient.revoke(refreshToken, clientId, clientSecret, AuthConstants.OAuth2.TOKEN_TYPE_REFRESH);
         } catch (Exception e) {
             throw new CustomException(AuthErrorCode.APPLE_REVOKE_FAILED);

--- a/src/main/java/com/heartz/byeboo/infrastructure/api/apple/AppleOAuthProvider.java
+++ b/src/main/java/com/heartz/byeboo/infrastructure/api/apple/AppleOAuthProvider.java
@@ -51,7 +51,6 @@ public class AppleOAuthProvider implements OAuthProvider {
     @Override
     public void requestRevoke(String refreshToken, final String serialId) {
         try {
-            System.out.println("리프레"+refreshToken);
             String clientSecret = appleClientSecretGenerator.generateClientSecret();
             appleFeignClient.revoke(refreshToken, clientId, clientSecret, AuthConstants.OAuth2.TOKEN_TYPE_REFRESH);
         } catch (Exception e) {

--- a/src/main/java/com/heartz/byeboo/infrastructure/api/kakao/KakaoOAuthProvider.java
+++ b/src/main/java/com/heartz/byeboo/infrastructure/api/kakao/KakaoOAuthProvider.java
@@ -1,5 +1,6 @@
 package com.heartz.byeboo.infrastructure.api.kakao;
 
+import com.heartz.byeboo.application.command.auth.ProviderUserInfoCommand;
 import com.heartz.byeboo.constants.AuthConstants;
 import com.heartz.byeboo.infrastructure.dto.SocialInfoResponse;
 import com.heartz.byeboo.infrastructure.dto.kakao.KakaoUserInfo;
@@ -20,12 +21,13 @@ public class KakaoOAuthProvider implements OAuthProvider
     private String adminKey;
 
     @Override
-    public SocialInfoResponse getUserInfo(String providerToken) {
-        KakaoAccessToken kakaoAccessToken = createKakaoAccessToken(providerToken);
+    public SocialInfoResponse getUserInfo(ProviderUserInfoCommand command) {
+        KakaoAccessToken kakaoAccessToken = createKakaoAccessToken(command.providerToken());
         String accessTokenWithTokenType = kakaoAccessToken.getAccessTokenWithTokenType();
         KakaoUserInfo kakaoUserInfo = kakaoFeignClient.getUserInfo(accessTokenWithTokenType);
         return SocialInfoResponse.of(
-                kakaoUserInfo.id().toString()
+                kakaoUserInfo.id().toString(),
+                null
         );
     }
 

--- a/src/main/java/com/heartz/byeboo/infrastructure/dto/SocialInfoResponse.java
+++ b/src/main/java/com/heartz/byeboo/infrastructure/dto/SocialInfoResponse.java
@@ -1,10 +1,17 @@
 package com.heartz.byeboo.infrastructure.dto;
 
+import lombok.Builder;
+
+@Builder
 public record SocialInfoResponse(
-        String serialId
+        String serialId,
+        String refreshToken
 )
 {
-    public static SocialInfoResponse of(final String serialId) {
-        return new SocialInfoResponse(serialId);
+    public static SocialInfoResponse of(final String serialId, String refreshToken) {
+        return SocialInfoResponse.builder()
+                .serialId(serialId)
+                .refreshToken(refreshToken)
+                .build();
     }
 }

--- a/src/main/java/com/heartz/byeboo/mapper/UserMapper.java
+++ b/src/main/java/com/heartz/byeboo/mapper/UserMapper.java
@@ -19,7 +19,8 @@ public class UserMapper {
                 user.getRole(),
                 user.getSerialId(),
                 user.getStatus(),
-                user.getDeletedAt()
+                user.getDeletedAt(),
+                user.getRefreshToken()
 
         );
     }
@@ -35,15 +36,9 @@ public class UserMapper {
                 userEntity.getRole(),
                 userEntity.getSerialId(),
                 userEntity.getStatus(),
-                userEntity.getDeletedAt()
+                userEntity.getDeletedAt(),
+                userEntity.getRefreshToken()
         );
-    }
-
-    public static User commandToDomain(UserCreateCommand userCreateCommand) {
-        return User.builder()
-                .name(userCreateCommand.getName())
-                .questStyle(userCreateCommand.getQuestStyle())
-                .build();
     }
 
     public static UserEntity toEntityForUpdate(User user) {
@@ -57,18 +52,20 @@ public class UserMapper {
                 user.getRole(),
                 user.getSerialId(),
                 user.getStatus(),
-                user.getDeletedAt()
+                user.getDeletedAt(),
+                user.getRefreshToken()
         );
     }
 
 
 
 
-    public static User userInfoToDomain(String serialId, EPlatform platform, ERole role){
+    public static User userInfoToDomain(String serialId, EPlatform platform, ERole role, String refreshToken){
         return User.builder()
                 .serialId(serialId)
                 .platform(platform)
                 .role(role)
+                .refreshToken(refreshToken)
                 .build();
     }
 


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->

사용성 측면에서 기존에 탈퇴할때 authorization code를 받기위해 로그인을 한번 더 했어야했는데 사용성 측면에서 좋지 않기 때문에 수정
- closes #162 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [x] authorization_code 기존에 헤더에서 받 -> 안받
- [x] 로그인에서 authorization_code 받도록 수정
- [x] 자잘한 인터페이스 수정

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
<로직>
1. 로그인을 하기위해 애플에서 identityToken을 받아올때 authorization_code을 같이 받아서 서버에 전달
2. 서버에서 authorization_code를 가지고 /token API를 통해서 만료기간이 없는 애플 refresh token 받아서 db에 저장
3. 탈퇴 요청시 저장해둔 refresh token을 가지고/revoke API를 호출
