### PR TITLE
Refac : 회원 탈퇴시 데이터 삭제, 예외처리, 새로운 여정 시작 여정 상태 수정

### DIFF
--- a/src/main/java/com/heartz/byeboo/adapter/out/UserJourneyPersistenceAdapter.java
+++ b/src/main/java/com/heartz/byeboo/adapter/out/UserJourneyPersistenceAdapter.java
@@ -3,6 +3,7 @@ package com.heartz.byeboo.adapter.out;
 import com.heartz.byeboo.adapter.out.persistence.entity.UserJourneyEntity;
 import com.heartz.byeboo.adapter.out.persistence.repository.UserJourneyRepository;
 import com.heartz.byeboo.application.port.out.user.CreateUserJourneyPort;
+import com.heartz.byeboo.application.port.out.user.DeleteUserJourneyPort;
 import com.heartz.byeboo.application.port.out.user.RetrieveUserJourneyPort;
 import com.heartz.byeboo.application.port.out.user.UpdateUserJourneyPort;
 import com.heartz.byeboo.core.exception.CustomException;
@@ -19,7 +20,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Component
-public class UserJourneyPersistenceAdapter implements CreateUserJourneyPort, RetrieveUserJourneyPort, UpdateUserJourneyPort {
+public class UserJourneyPersistenceAdapter implements CreateUserJourneyPort, RetrieveUserJourneyPort, UpdateUserJourneyPort, DeleteUserJourneyPort {
     private final UserJourneyRepository userJourneyRepository;
 
     @Override
@@ -70,4 +71,8 @@ public class UserJourneyPersistenceAdapter implements CreateUserJourneyPort, Ret
         userJourneyRepository.save(userJourneyEntity);
     }
 
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        userJourneyRepository.deleteAllByUserId(userId);
+    }
 }

--- a/src/main/java/com/heartz/byeboo/adapter/out/UserPersistenceAdapter.java
+++ b/src/main/java/com/heartz/byeboo/adapter/out/UserPersistenceAdapter.java
@@ -3,6 +3,7 @@ package com.heartz.byeboo.adapter.out;
 import com.heartz.byeboo.adapter.out.persistence.entity.UserEntity;
 import com.heartz.byeboo.adapter.out.persistence.repository.UserRepository;
 import com.heartz.byeboo.application.port.out.user.CreateUserPort;
+import com.heartz.byeboo.application.port.out.user.DeleteUserPort;
 import com.heartz.byeboo.application.port.out.user.RetrieveUserPort;
 import com.heartz.byeboo.application.port.out.user.UpdateUserPort;
 import com.heartz.byeboo.core.exception.CustomException;
@@ -19,7 +20,7 @@ import java.util.Optional;
 
 @RequiredArgsConstructor
 @Component
-public class UserPersistenceAdapter implements CreateUserPort, RetrieveUserPort, UpdateUserPort {
+public class UserPersistenceAdapter implements CreateUserPort, RetrieveUserPort, UpdateUserPort, DeleteUserPort {
     private final UserRepository userRepository;
 
 
@@ -68,4 +69,8 @@ public class UserPersistenceAdapter implements CreateUserPort, RetrieveUserPort,
     }
 
 
+    @Override
+    public void deleteUserById(Long userId) {
+        userRepository.deleteById(userId);
+    }
 }

--- a/src/main/java/com/heartz/byeboo/adapter/out/UserQuestPersistenceAdapter.java
+++ b/src/main/java/com/heartz/byeboo/adapter/out/UserQuestPersistenceAdapter.java
@@ -3,6 +3,7 @@ package com.heartz.byeboo.adapter.out;
 import com.heartz.byeboo.adapter.out.persistence.entity.UserQuestEntity;
 import com.heartz.byeboo.adapter.out.persistence.repository.UserQuestRepository;
 import com.heartz.byeboo.application.port.out.userquest.CreateUserQuestPort;
+import com.heartz.byeboo.application.port.out.userquest.DeleteUserQuestPort;
 import com.heartz.byeboo.application.port.out.userquest.RetrieveUserQuestPort;
 import com.heartz.byeboo.core.exception.CustomException;
 import com.heartz.byeboo.domain.exception.UserQuestErrorCode;
@@ -16,7 +17,7 @@ import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
-public class UserQuestPersistenceAdapter implements CreateUserQuestPort, RetrieveUserQuestPort {
+public class UserQuestPersistenceAdapter implements CreateUserQuestPort, RetrieveUserQuestPort, DeleteUserQuestPort {
 
     private final UserQuestRepository userQuestRepository;
 
@@ -54,5 +55,10 @@ public class UserQuestPersistenceAdapter implements CreateUserQuestPort, Retriev
         }
 
         return UserQuestMapper.toDomainRecording(userQuestEntity, user, quest);
+    }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        userQuestRepository.deleteAllByUserId(userId);
     }
 }

--- a/src/main/java/com/heartz/byeboo/adapter/out/persistence/repository/UserJourneyRepository.java
+++ b/src/main/java/com/heartz/byeboo/adapter/out/persistence/repository/UserJourneyRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface UserJourneyRepository extends JpaRepository<UserJourneyEntity, Long> {
     List<UserJourneyEntity> findAllByUserId(Long userId);
     Optional<UserJourneyEntity> findByUserIdAndJourney(Long userId, EJourney journey);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/heartz/byeboo/adapter/out/persistence/repository/UserQuestRepository.java
+++ b/src/main/java/com/heartz/byeboo/adapter/out/persistence/repository/UserQuestRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 public interface UserQuestRepository extends JpaRepository<UserQuestEntity, Long> {
     List<UserQuestEntity> findAllByUserIdAndQuestIdOrderByCreatedDateDesc(Long userId, Long questId);
     Optional<UserQuestEntity> findByUserIdAndQuestId(Long userId, Long questId);
+    void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/heartz/byeboo/application/port/out/user/DeleteUserJourneyPort.java
+++ b/src/main/java/com/heartz/byeboo/application/port/out/user/DeleteUserJourneyPort.java
@@ -1,0 +1,5 @@
+package com.heartz.byeboo.application.port.out.user;
+
+public interface DeleteUserJourneyPort {
+    void deleteAllByUserId(Long userId);
+}

--- a/src/main/java/com/heartz/byeboo/application/port/out/user/DeleteUserPort.java
+++ b/src/main/java/com/heartz/byeboo/application/port/out/user/DeleteUserPort.java
@@ -1,0 +1,7 @@
+package com.heartz.byeboo.application.port.out.user;
+
+import com.heartz.byeboo.domain.model.User;
+
+public interface DeleteUserPort {
+    void deleteUserById(Long userId);
+}

--- a/src/main/java/com/heartz/byeboo/application/port/out/userquest/DeleteUserQuestPort.java
+++ b/src/main/java/com/heartz/byeboo/application/port/out/userquest/DeleteUserQuestPort.java
@@ -1,0 +1,5 @@
+package com.heartz.byeboo.application.port.out.userquest;
+
+public interface DeleteUserQuestPort {
+    void deleteAllByUserId(Long userId);
+}

--- a/src/main/java/com/heartz/byeboo/application/service/auth/OAuthService.java
+++ b/src/main/java/com/heartz/byeboo/application/service/auth/OAuthService.java
@@ -13,10 +13,8 @@ import com.heartz.byeboo.application.port.out.token.CreateTokenPort;
 import com.heartz.byeboo.application.port.out.token.DeleteTokenPort;
 import com.heartz.byeboo.application.port.out.token.RetrieveTokenPort;
 import com.heartz.byeboo.application.port.out.token.UpdateTokenPort;
-import com.heartz.byeboo.application.port.out.user.CreateUserPort;
-import com.heartz.byeboo.application.port.out.user.RetrieveUserJourneyPort;
-import com.heartz.byeboo.application.port.out.user.RetrieveUserPort;
-import com.heartz.byeboo.application.port.out.user.UpdateUserPort;
+import com.heartz.byeboo.application.port.out.user.*;
+import com.heartz.byeboo.application.port.out.userquest.DeleteUserQuestPort;
 import com.heartz.byeboo.domain.model.Token;
 import com.heartz.byeboo.domain.model.User;
 import com.heartz.byeboo.domain.model.UserJourney;
@@ -45,12 +43,14 @@ public class OAuthService implements OAuthUseCase {
     private final CreateUserPort createUserPort;
     private final JwtProvider jwtProvider;
     private final JwtValidator jwtValidator;
-    private final UpdateUserPort updateUserPort;
     private final CreateTokenPort createTokenPort;
     private final DeleteTokenPort deleteTokenPort;
     private final RetrieveTokenPort retrieveTokenPort;
     private final UpdateTokenPort updateTokenPort;
     private final RetrieveUserJourneyPort retrieveUserJourneyPort;
+    private final DeleteUserPort deleteUserPort;
+    private final DeleteUserQuestPort deleteUserQuestPort;
+    private final DeleteUserJourneyPort deleteUserJourneyPort;
 
 
     @Transactional
@@ -99,8 +99,11 @@ public class OAuthService implements OAuthUseCase {
     public Void withdraw(OAuthWithdrawCommand command) {
         User findUser = retrieveUserPort.getUserById(command.userId());
         oAuthUserInfoAdapter.revoke(findUser.getPlatform(), command.code(), findUser.getSerialId());
-        findUser.softDelete();
-        updateUserPort.updateUser(findUser);
+        deleteUserQuestPort.deleteAllByUserId(findUser.getId());
+        deleteUserJourneyPort.deleteAllByUserId(findUser.getId());
+        deleteUserPort.deleteUserById(findUser.getId());
+        //findUser.softDelete();
+        //updateUserPort.updateUser(findUser);
         return null;
     }
 

--- a/src/main/java/com/heartz/byeboo/application/service/user/UserService.java
+++ b/src/main/java/com/heartz/byeboo/application/service/user/UserService.java
@@ -9,16 +9,14 @@ import com.heartz.byeboo.application.port.out.user.*;
 import com.heartz.byeboo.application.port.out.userquest.RetrieveUserQuestPort;
 import com.heartz.byeboo.constants.QuestConstants;
 import com.heartz.byeboo.core.exception.CustomException;
+import com.heartz.byeboo.domain.exception.UserErrorCode;
 import com.heartz.byeboo.domain.exception.UserJourneyErrorCode;
 import com.heartz.byeboo.domain.exception.UserQuestErrorCode;
 import com.heartz.byeboo.domain.model.Quest;
 import com.heartz.byeboo.domain.model.User;
 import com.heartz.byeboo.domain.model.UserJourney;
 import com.heartz.byeboo.domain.model.UserQuest;
-import com.heartz.byeboo.domain.type.ECharacterDialogue;
-import com.heartz.byeboo.domain.type.EJourney;
-import com.heartz.byeboo.domain.type.EJourneyStatus;
-import com.heartz.byeboo.domain.type.EUserCurrentStatus;
+import com.heartz.byeboo.domain.type.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,6 +43,10 @@ public class UserService implements UserUseCase {
     public UserCreateResponseDto updateUser(UserCreateCommand userCreateCommand) {
         User currentUser = retrieveUserPort.getUserById(userCreateCommand.getUserId());
        //User currentUser = UserMapper.commandToDomain(userCreateCommand);
+
+        if(currentUser.getStatus() == ACTIVE){
+            throw new CustomException(UserErrorCode.ALREADY_PROCEED_ONBOARDING);
+        }
 
         EJourney initialJourney = switch (userCreateCommand.getQuestStyle()) {
             case RECORDING -> EJourney.FACE_EMOTION;

--- a/src/main/java/com/heartz/byeboo/application/service/userquest/UserQuestService.java
+++ b/src/main/java/com/heartz/byeboo/application/service/userquest/UserQuestService.java
@@ -128,7 +128,7 @@ public class UserQuestService implements UserQuestUseCase {
         findUserJourney.updateInitialUserJourney();
         findUser.updateJourney(command.getJourney());
         updateUserJourneyPort.updateUserJourney(findUserJourney);
-        findUser.startNewJourney();
+        findUser.initializeCurrentNumber();
         updateUserPort.updateCurrentNumber(findUser);
     }
 

--- a/src/main/java/com/heartz/byeboo/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/heartz/byeboo/domain/exception/UserErrorCode.java
@@ -11,7 +11,8 @@ public enum UserErrorCode implements ErrorCode {
     USER_NAME_TOO_SHORT(HttpStatus.BAD_REQUEST,"유저 이름은 최소 2자 이상입니다."),
     USER_NAME_TOO_LONG(HttpStatus.BAD_REQUEST,"유저 이름은 최대 5자 이하입니다."),
     INVALID_QUEST_STYLE(HttpStatus.BAD_REQUEST, "올바르지 않은 퀘스트 방식입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다.")
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
+    ALREADY_PROCEED_ONBOARDING(HttpStatus.BAD_REQUEST, "이미 온보딩을 진행한 유저 입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/heartz/byeboo/domain/model/User.java
+++ b/src/main/java/com/heartz/byeboo/domain/model/User.java
@@ -42,9 +42,9 @@ public class User {
         this.currentNumber = 0L;
     }
 
-    public void startNewJourney(){
-        this.currentNumber = 1L;
-    }
+//    public void startNewJourney(){
+//        this.currentNumber = 1L;
+//    }
 
     public void updateQuestStyle(EQuestStyle questStyle){
         this.questStyle = questStyle;

--- a/src/main/java/com/heartz/byeboo/domain/model/UserJourney.java
+++ b/src/main/java/com/heartz/byeboo/domain/model/UserJourney.java
@@ -73,7 +73,7 @@ public class UserJourney {
 
     public void updateInitialUserJourney() {
         this.journeyStart = LocalDate.now();
-        this.journeyStatus = EJourneyStatus.IN_PROGRESS;
+        this.journeyStatus = EJourneyStatus.BEFORE_START;
     }
 
     public void updateUserJourneyCompleted(){


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #164 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [ ] 회원 탈퇴시 유저와 관련된 모든 데이터 삭제
- [ ] INACTIVE 유저만 온보딩 시작 하도록 예외 처리
- [ ]  새로운 여정 시작 API 호출 시 BEFORE_START로 여정 상태 업데이트

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->