### PR TITLE
[Feat] : 댓글 수정 API 구현

### DIFF
--- a/src/main/java/com/heartz/byeboo/adapter/in/web/controller/CommentController.java
+++ b/src/main/java/com/heartz/byeboo/adapter/in/web/controller/CommentController.java
@@ -1,7 +1,9 @@
 package com.heartz.byeboo.adapter.in.web.controller;
 
 import com.heartz.byeboo.adapter.in.web.dto.request.CommentCreateRequestDto;
+import com.heartz.byeboo.adapter.in.web.dto.request.CommentUpdateRequestDto;
 import com.heartz.byeboo.application.command.comment.CommentCreateCommand;
+import com.heartz.byeboo.application.command.comment.CommentUpdateCommand;
 import com.heartz.byeboo.application.port.in.usecase.CommentUseCase;
 import com.heartz.byeboo.core.annotation.UserId;
 import com.heartz.byeboo.core.common.BaseResponse;
@@ -9,9 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,7 +27,7 @@ public class CommentController {
             responses = {
                     @ApiResponse(
                             responseCode = "200",
-                            description = "토큰 저장 성공"
+                            description = "댓글 저장 성공"
                     ),
                     @ApiResponse(
                             responseCode = "404",
@@ -47,6 +47,35 @@ public class CommentController {
             ){
         CommentCreateCommand command = CommentCreateCommand.of(userId, commentCreateRequestDto);
         return BaseResponse.success(commentUseCase.createComment(command));
+    }
+
+    @Operation(
+            summary = "댓글 수정",
+            description = "댓글 수정하는 API 입니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "댓글 수정 성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "존재하지 않는 유저일때"
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 에러"
+                    )
+            }
+    )
+
+    @PatchMapping ("/{commentId}")
+    public BaseResponse<Void> updateComment(
+            final CommentUpdateRequestDto commentUpdateRequestDto,
+            @UserId Long userId,
+            @PathVariable Long commentId
+    ){
+        CommentUpdateCommand command = CommentUpdateCommand.of(userId, commentUpdateRequestDto,commentId);
+        return BaseResponse.success(commentUseCase.updateComment(command));
     }
 
 }

--- a/src/main/java/com/heartz/byeboo/adapter/in/web/dto/request/CommentUpdateRequestDto.java
+++ b/src/main/java/com/heartz/byeboo/adapter/in/web/dto/request/CommentUpdateRequestDto.java
@@ -1,0 +1,6 @@
+package com.heartz.byeboo.adapter.in.web.dto.request;
+
+public record CommentUpdateRequestDto(
+        String content
+) {
+}

--- a/src/main/java/com/heartz/byeboo/adapter/out/CommentPersistenceAdapter.java
+++ b/src/main/java/com/heartz/byeboo/adapter/out/CommentPersistenceAdapter.java
@@ -1,23 +1,45 @@
 package com.heartz.byeboo.adapter.out;
 
 import com.heartz.byeboo.adapter.out.persistence.entity.CommentEntity;
+import com.heartz.byeboo.adapter.out.persistence.entity.CommonQuestEntity;
 import com.heartz.byeboo.adapter.out.persistence.repository.CommentRepository;
 import com.heartz.byeboo.application.port.out.comment.CreateCommentPort;
+import com.heartz.byeboo.application.port.out.comment.RetrieveCommentPort;
+import com.heartz.byeboo.application.port.out.comment.UpdateCommentPort;
+import com.heartz.byeboo.core.exception.CustomException;
+import com.heartz.byeboo.domain.exception.CommentErrorCode;
+import com.heartz.byeboo.domain.exception.CommonQuestErrorCode;
 import com.heartz.byeboo.domain.model.Comment;
 import com.heartz.byeboo.mapper.CommentMapper;
+import com.heartz.byeboo.mapper.CommonQuestMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 
 @RequiredArgsConstructor
 @Component
-public class CommentPersistenceAdapter implements CreateCommentPort {
+public class CommentPersistenceAdapter implements CreateCommentPort, RetrieveCommentPort, UpdateCommentPort {
 
     private final CommentRepository commentRepository;
 
     @Override
     public void createComment(Comment comment) {
         CommentEntity commentEntity = CommentMapper.toEntity(comment);
+        commentRepository.save(commentEntity);
+    }
+
+    @Override
+    public Comment getCommentByIdAndUserId(Long commentId, Long userId) {
+        CommentEntity commonQuestEntity = commentRepository.findByUserIdAndId(userId, commentId)
+                .orElseThrow(() -> new CustomException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        return CommentMapper.toDomain(commonQuestEntity);
+    }
+
+    @Override
+    public void updateComment(Comment comment) {
+        CommentEntity commentEntity = CommentMapper.toEntityForUpdate(comment);
+
         commentRepository.save(commentEntity);
     }
 }

--- a/src/main/java/com/heartz/byeboo/adapter/out/persistence/entity/CommentEntity.java
+++ b/src/main/java/com/heartz/byeboo/adapter/out/persistence/entity/CommentEntity.java
@@ -27,10 +27,11 @@ public class CommentEntity extends BaseEntity{
     private Long userCommonQuestId;
 
     @Builder
-    public CommentEntity(String content, Long userId, Long userCommonQuestId) {
+    public CommentEntity(String content, Long userId, Long userCommonQuestId, Long id) {
         this.userId = userId;
         this.content = content;
         this.userCommonQuestId = userCommonQuestId;
+        this.id = id;
     }
 
     public static CommentEntity create(String content, Long userId, Long userCommonQuestId) {

--- a/src/main/java/com/heartz/byeboo/adapter/out/persistence/repository/CommentRepository.java
+++ b/src/main/java/com/heartz/byeboo/adapter/out/persistence/repository/CommentRepository.java
@@ -1,7 +1,11 @@
 package com.heartz.byeboo.adapter.out.persistence.repository;
 
 import com.heartz.byeboo.adapter.out.persistence.entity.CommentEntity;
+import com.heartz.byeboo.domain.model.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+    Optional<CommentEntity> findByUserIdAndId(Long userId, Long id);
 }

--- a/src/main/java/com/heartz/byeboo/application/command/comment/CommentUpdateCommand.java
+++ b/src/main/java/com/heartz/byeboo/application/command/comment/CommentUpdateCommand.java
@@ -1,0 +1,23 @@
+package com.heartz.byeboo.application.command.comment;
+
+import com.heartz.byeboo.adapter.in.web.dto.request.CommentUpdateRequestDto;
+import com.heartz.byeboo.application.command.quest.AllQuestProgressCommand;
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentUpdateCommand {
+    private String content;
+    private Long userId;
+    private Long commentId;
+
+    public static CommentUpdateCommand of(Long userId, CommentUpdateRequestDto commentUpdateRequestDto, Long commentId) {
+        return CommentUpdateCommand.builder()
+                .userId(userId)
+                .commentId(commentId)
+                .content(commentUpdateRequestDto.content())
+                .build();
+    }
+}

--- a/src/main/java/com/heartz/byeboo/application/port/in/usecase/CommentUseCase.java
+++ b/src/main/java/com/heartz/byeboo/application/port/in/usecase/CommentUseCase.java
@@ -2,7 +2,9 @@ package com.heartz.byeboo.application.port.in.usecase;
 
 
 import com.heartz.byeboo.application.command.comment.CommentCreateCommand;
+import com.heartz.byeboo.application.command.comment.CommentUpdateCommand;
 
 public interface CommentUseCase {
     Void createComment(CommentCreateCommand command);
+    Void updateComment(CommentUpdateCommand command);
 }

--- a/src/main/java/com/heartz/byeboo/application/port/out/comment/RetrieveCommentPort.java
+++ b/src/main/java/com/heartz/byeboo/application/port/out/comment/RetrieveCommentPort.java
@@ -1,0 +1,7 @@
+package com.heartz.byeboo.application.port.out.comment;
+
+import com.heartz.byeboo.domain.model.Comment;
+
+public interface RetrieveCommentPort {
+    Comment getCommentByIdAndUserId(Long commentId, Long userId);
+}

--- a/src/main/java/com/heartz/byeboo/application/port/out/comment/UpdateCommentPort.java
+++ b/src/main/java/com/heartz/byeboo/application/port/out/comment/UpdateCommentPort.java
@@ -1,0 +1,7 @@
+package com.heartz.byeboo.application.port.out.comment;
+
+import com.heartz.byeboo.domain.model.Comment;
+
+public interface UpdateCommentPort {
+    void updateComment(Comment comment);
+}

--- a/src/main/java/com/heartz/byeboo/application/service/comment/CommentService.java
+++ b/src/main/java/com/heartz/byeboo/application/service/comment/CommentService.java
@@ -1,14 +1,18 @@
 package com.heartz.byeboo.application.service.comment;
 
 import com.heartz.byeboo.application.command.comment.CommentCreateCommand;
+import com.heartz.byeboo.application.command.comment.CommentUpdateCommand;
 import com.heartz.byeboo.application.port.in.usecase.CommentUseCase;
 import com.heartz.byeboo.application.port.out.comment.CreateCommentPort;
+import com.heartz.byeboo.application.port.out.comment.RetrieveCommentPort;
+import com.heartz.byeboo.application.port.out.comment.UpdateCommentPort;
 import com.heartz.byeboo.application.port.out.user.RetrieveUserPort;
 import com.heartz.byeboo.application.port.out.usercommonquest.RetrieveUserCommonQuestPort;
 import com.heartz.byeboo.domain.model.*;
 import com.heartz.byeboo.mapper.CommentMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -16,16 +20,29 @@ import org.springframework.stereotype.Service;
 public class CommentService implements CommentUseCase {
 
     private final RetrieveUserPort retrieveUserPort;
-    private final RetrieveUserCommonQuestPort retrieveUserCommonQuestPort;
     private final CreateCommentPort createCommentPort;
+    private final RetrieveUserCommonQuestPort retrieveUserCommonQuestPort;
+    private final RetrieveCommentPort retrieveCommentPort;
+    private final UpdateCommentPort updateCommentPort;
 
     @Override
+    @Transactional
     public Void createComment(CommentCreateCommand command) {
-        User findUser = retrieveUserPort.getUserById(command.getUserId());
-        UserCommonQuest findUserCommonQuest = retrieveUserCommonQuestPort.getUserCommonQuestById(command.getTargetId());
-        Comment comment = CommentMapper.commandToDomain(command, findUser, findUserCommonQuest);
+        retrieveUserPort.getUserById(command.getUserId());
+        retrieveUserCommonQuestPort.getUserCommonQuestById(command.getTargetId());
+        Comment comment = CommentMapper.commandToDomain(command);
 
         createCommentPort.createComment(comment);
+
+        return null;
+    }
+
+    @Override
+    @Transactional
+    public Void updateComment(CommentUpdateCommand command) {
+        Comment comment = retrieveCommentPort.getCommentByIdAndUserId(command.getCommentId(), command.getUserId());
+        comment.updateContent(command.getContent());
+        updateCommentPort.updateComment(comment);
 
         return null;
     }

--- a/src/main/java/com/heartz/byeboo/domain/exception/CommentErrorCode.java
+++ b/src/main/java/com/heartz/byeboo/domain/exception/CommentErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommentErrorCode implements ErrorCode {
 
-    COMMENT_TOO_LONG(HttpStatus.BAD_REQUEST, "500자 이하로 작성해주세요")
+    COMMENT_TOO_LONG(HttpStatus.BAD_REQUEST, "500자 이하로 작성해주세요"),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다.")
     ;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/heartz/byeboo/domain/model/Comment.java
+++ b/src/main/java/com/heartz/byeboo/domain/model/Comment.java
@@ -7,16 +7,20 @@ import lombok.Getter;
 @Builder
 public class Comment {
     private Long id;
-    private User user;
+    private Long userId;
     private String content;
-    private UserCommonQuest userCommonQuest;
+    private Long userCommonQuestId;
 
-    public static Comment of(Long id, User user, UserCommonQuest userCommonQuest, String content) {
+    public static Comment of(Long id, Long userId, Long userCommonQuestId, String content) {
         return Comment.builder()
                 .id(id)
-                .user(user)
-                .userCommonQuest(userCommonQuest)
+                .userId(userId)
+                .userCommonQuestId(userCommonQuestId)
                 .content(content)
                 .build();
+    }
+
+    public void updateContent(String content){
+        this.content = content;
     }
 }

--- a/src/main/java/com/heartz/byeboo/mapper/CommentMapper.java
+++ b/src/main/java/com/heartz/byeboo/mapper/CommentMapper.java
@@ -9,19 +9,37 @@ import com.heartz.byeboo.domain.model.UserCommonQuest;
 
 
 public class CommentMapper {
-    public static Comment commandToDomain(CommentCreateCommand command, User user, UserCommonQuest userCommonQuest) {
+    public static Comment commandToDomain(CommentCreateCommand command) {
         return Comment.builder()
                 .content(command.getContent())
-                .user(user)
-                .userCommonQuest(userCommonQuest)
+                .userId(command.getUserId())
+                .userCommonQuestId(command.getTargetId())
                 .build();
     }
 
     public static CommentEntity toEntity(Comment comment) {
         return CommentEntity.create(
                 comment.getContent(),
-                comment.getUser().getId(),
-                comment.getUserCommonQuest().getId()
+                comment.getUserId(),
+                comment.getUserCommonQuestId()
         );
+    }
+
+    public static Comment toDomain(CommentEntity commentEntity){
+        return Comment.of(
+                commentEntity.getId(),
+                commentEntity.getUserId(),
+                commentEntity.getUserCommonQuestId(),
+                commentEntity.getContent()
+        );
+    }
+
+    public static CommentEntity toEntityForUpdate(Comment comment) {
+        return CommentEntity.builder()
+                .id(comment.getId())
+                .userId(comment.getUserId())
+                .userCommonQuestId(comment.getUserCommonQuestId())
+                .content(comment.getContent())
+                .build();
     }
 }


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #294 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [x] 댓글 수정 API 구현

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
고민-기존에는 댓글 도메인 모델이 게시글 객체를 직접 참조하는 구조
댓글을 수정하거나 단순 조회하는 경우에도 게시글 객체까지 함께 조회하거나 주입해야 했고, 이 과정에서 불필요한 조회가 발생할 수 있다고 판단

해결 - 댓글과 게시글은 같은 Aggregate라기보다는, 댓글이 게시글을 참조하는 관계에 가깝다고 보았음
댓글이 수정된다고 해서 게시글의 상태가 함께 변경되는 것은 아니며, 댓글은 게시글의 생명주기를 직접 관리하지 않음 따라서 댓글 도메인 모델에는 게시글 객체 전체를 두기보다 id만 둬서 간접 참조하도록 수정

나머지 도메인 모델들도 같은 기준으로 Aggregate 관계와 단순 참조 관계를 구분하여 리팩토링할 예정입니다.