### PR TITLE
[fix] : 쿼리문 left join으로 변경

### DIFF
--- a/src/main/java/com/heartz/byeboo/adapter/out/persistence/repository/NotificationRepository.java
+++ b/src/main/java/com/heartz/byeboo/adapter/out/persistence/repository/NotificationRepository.java
@@ -12,10 +12,16 @@ import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<NotificationEntity, Long> {
 
-    @Query("SELECT n.id AS notificationId, n.notificationType AS type, u.name AS senderNickname, n.targetId as targetId, n.landingUrl AS landingUrl, n.isRead AS isRead, n.createdDate as createdAt " +
-            "FROM NotificationEntity n JOIN UserEntity u ON n.senderUserId = u.id " +
+    @Query("SELECT n.id AS notificationId, " +
+            "n.notificationType AS type, " +
+            "u.name AS senderNickname, " +
+            "n.targetId AS targetId, " +
+            "n.landingUrl AS landingUrl, " +
+            "n.isRead AS isRead, " +
+            "n.createdDate AS createdAt " +
+            "FROM NotificationEntity n LEFT JOIN UserEntity u ON n.senderUserId = u.id " +
             "WHERE n.userId = :userId " +
-            "order by n.createdDate desc")
+            "ORDER BY n.createdDate DESC")
     List<NotificationProjection> findAllByUserId(Long userId);
     void deleteByCreatedDateBefore(LocalDateTime threshold);
     NotificationEntity findByUserIdAndId(Long userId, Long id);


### PR DESCRIPTION
## 관련 이슈 🛠
<!-- 관련 이슈 번호를 적어주세요. -->
- closes #349 

## 작업 내용 ✏️
<!-- 작업 내용을 간단히 작성해주세요. -->
- [ ] 

## To Reviewers 📢
<!-- 리뷰어들에게 물어볼 점 등을 필요하다면 작성해주세요. -->
기존에 QUEST_OPEN 알림에서 sender_user_id null로 설정되서 이너 조인에 의해 조회 결과에서 빠짐
=> left join으로 변경해서 알림 엔티티 기준으로 조인